### PR TITLE
ajout de avoid_manga

### DIFF
--- a/.idea/MangAnnuaire.iml
+++ b/.idea/MangAnnuaire.iml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<module type="JAVA_MODULE" version="4">
+  <component name="NewModuleRootManager" inherit-compiler-output="true">
+    <exclude-output />
+    <content url="file://$MODULE_DIR$" />
+    <orderEntry type="inheritedJdk" />
+    <orderEntry type="sourceFolder" forTests="false" />
+  </component>
+</module>

--- a/.idea/misc.xml
+++ b/.idea/misc.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="ProjectRootManager">
+    <output url="file://$PROJECT_DIR$/out" />
+  </component>
+</project>

--- a/.idea/modules.xml
+++ b/.idea/modules.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="ProjectModuleManager">
+    <modules>
+      <module fileurl="file://$PROJECT_DIR$/.idea/MangAnnuaire.iml" filepath="$PROJECT_DIR$/.idea/MangAnnuaire.iml" />
+    </modules>
+  </component>
+</project>

--- a/.idea/vcs.xml
+++ b/.idea/vcs.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="VcsDirectoryMappings">
+    <mapping directory="" vcs="Git" />
+  </component>
+</project>

--- a/.idea/workspace.xml
+++ b/.idea/workspace.xml
@@ -1,0 +1,44 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="ChangeListManager">
+    <list default="true" id="097fe7d7-d1de-4a57-9643-1704e9fd76b8" name="Changes" comment="" />
+    <option name="SHOW_DIALOG" value="false" />
+    <option name="HIGHLIGHT_CONFLICTS" value="true" />
+    <option name="HIGHLIGHT_NON_ACTIVE_CHANGELIST" value="false" />
+    <option name="LAST_RESOLUTION" value="IGNORE" />
+  </component>
+  <component name="Git.Settings">
+    <option name="RECENT_GIT_ROOT_PATH" value="$PROJECT_DIR$" />
+  </component>
+  <component name="MarkdownSettingsMigration">
+    <option name="stateVersion" value="1" />
+  </component>
+  <component name="ProjectId" id="2axKOoZxrsPWHQvSpbH5oDmChKX" />
+  <component name="ProjectViewState">
+    <option name="hideEmptyMiddlePackages" value="true" />
+    <option name="showLibraryContents" value="true" />
+  </component>
+  <component name="PropertiesComponent"><![CDATA[{
+  "keyToString": {
+    "RunOnceActivity.ShowReadmeOnStart": "true",
+    "WebServerToolWindowFactoryState": "false",
+    "nodejs_package_manager_path": "npm",
+    "vue.rearranger.settings.migration": "true"
+  }
+}]]></component>
+  <component name="SpellCheckerSettings" RuntimeDictionaries="0" Folders="0" CustomDictionaries="0" DefaultDictionary="application-level" UseSingleDictionary="true" transferred="true" />
+  <component name="TaskManager">
+    <task active="true" id="Default" summary="Default task">
+      <changelist id="097fe7d7-d1de-4a57-9643-1704e9fd76b8" name="Changes" comment="" />
+      <created>1705254764056</created>
+      <option name="number" value="Default" />
+      <option name="presentableId" value="Default" />
+      <updated>1705254764056</updated>
+      <workItem from="1705254765953" duration="7000" />
+    </task>
+    <servers />
+  </component>
+  <component name="TypeScriptGeneratedFilesManager">
+    <option name="version" value="3" />
+  </component>
+</project>

--- a/avoid_manga.html
+++ b/avoid_manga.html
@@ -28,9 +28,36 @@
     </header>
     <main>
        
-        <section id="anime">
-            <h2>Anime </h2>
-        </section>
+        <h1>Mangas à Éviter</h1>
+
+        <ul class="manga-list">
+            <li>
+                <strong>Manga Controversé 1</strong>
+                <p>Raison : Contenu mature et graphique, non adapté à un public jeune.</p>
+            </li>
+    
+            <li>
+                <strong>Manga Incomplet 2</strong>
+                <p>Raison : Série inachevée, laissant de nombreuses questions sans réponse.</p>
+            </li>
+    
+            <li>
+                <strong>Manga Critiqué 3</strong>
+                <p>Raison : A reçu des critiques négatives pour ses personnages stéréotypés.</p>
+            </li>
+    
+            <li>
+                <strong>Manga Redondant 4</strong>
+                <p>Raison : L'intrigue est similaire à de nombreuses autres séries sans apporter de nouvelle perspective.</p>
+            </li>
+    
+            <li>
+                <strong>Manga de Faible Qualité 5</strong>
+                <p>Raison : Dessins de qualité inférieure et narration peu engageante.</p>
+            </li>
+        </ul>
+
+    
      
     </main>
     <footer>


### PR DESCRIPTION
### Description
Ajout de la page "Manga à Éviter" pour fournir une liste de mangas à éviter sur le site. Cette page vise à informer les utilisateurs des mangas susceptibles de ne pas correspondre à leurs préférences, basé sur des critères tels que le contenu mature, les critiques négatives, l'incomplétude, etc.

## Changements proposés
- Création de la page "Manga à Éviter"  (avoid_manga.html)
- Ajout d'une liste de mangas avec leur nom et la raison à éviter.

### Résout
Cette demande de pull adresse la nécessité d'inclure une liste de mangas à éviter sur le site.

### Étapes pour tester
go sur le lien dans la navbar A éviter

### Captures d'écran (le cas échéant)
[Ci-joint, des captures d'écran de la nouvelle page "Manga à Éviter" et de la liste de mangas.]

### Contexte additionnel
La création de cette page vise à améliorer l'expérience utilisateur en fournissant des informations utiles pour guider les choix de lecture des utilisateurs. Veillez à maintenir la liste à jour en fonction des retours des utilisateurs et des évolutions dans le monde des mangas.
